### PR TITLE
Add style options to title, subtitle and caption

### DIFF
--- a/R/lt-choropleth.R
+++ b/R/lt-choropleth.R
@@ -38,7 +38,10 @@ lt_choropleth <- function(data = NULL,
   tiles_opts <- dsopts_merge(..., categories = "maptiles")
   highlight_opts <- dsopts_merge(..., categories = "highlight")
   theme_opts <- dsopts_merge(..., categories = "theme")
-  title_opts <- dsopts_merge(..., categories = "titles")
+  title_opts <- c(
+    dsopts_merge(..., categories = "text"),
+    dsopts_merge(..., categories = "titles")
+  )
   lt <- leaflet(data_viz) |>
     lt_tiles(tiles_opts) |>
     addPolygons(

--- a/R/utils-titles.R
+++ b/R/utils-titles.R
@@ -1,18 +1,31 @@
 lt_titles <- function(lt, opts_titles) {
   lt |>
     addControl(
-      opts_titles$title,
+      html = make_heading("title", opts_titles),
       position = paste0("top", opts_titles$title_align),
       className = "map-title"
     ) |>
     addControl(
-      opts_titles$subtitle,
+      html = make_heading("subtitle", opts_titles),
       position = paste0("top", opts_titles$subtitle_align),
       className = "map-subtitle"
     ) |>
     addControl(
-      opts_titles$caption,
+      html = make_heading("caption", opts_titles),
       position = paste0("bottom", opts_titles$caption_align),
       className = "map-caption"
     )
+}
+
+make_heading <- function(heading, opts) {
+  color <- opts[[paste0(heading, "_color")]] %||% opts$text_color
+  font_family <- opts[[paste0(heading, "_family")]] %||% opts$text_family
+  font_size <- opts[[paste0(heading, "_size")]]
+  font_weight <- opts[[paste0(heading, "_weight")]]
+
+  glue::glue(
+    "<div style = 'font-family: {font_family}; font-size: {font_size}px; font-weight: {font_weight}; color: {color};>",
+    "{opts[[heading]]}",
+    "</div>"
+  )
 }

--- a/R/utils-titles.R
+++ b/R/utils-titles.R
@@ -24,7 +24,7 @@ make_heading <- function(heading, opts) {
   font_weight <- opts[[paste0(heading, "_weight")]]
 
   glue::glue(
-    "<div style = 'font-family: {font_family}; font-size: {font_size}px; font-weight: {font_weight}; color: {color};>",
+    "<div style = 'font-family: {font_family}; font-size: {font_size}px; font-weight: {font_weight}; color: {color};'>",
     "{opts[[heading]]}",
     "</div>"
   )


### PR DESCRIPTION
Added options for font family, size, weight and color for the map title, subtitle and caption. They work the same as in `hgmagic`.