### PR TITLE
DSPRJT-7132: Revisar paquete ltgeo

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,4 +2,13 @@
 
 export(lt_bubbles)
 export(lt_choropleth)
+export(lt_choropleth_Gcd)
+export(lt_choropleth_GcdCat)
+export(lt_choropleth_GcdNum)
+export(lt_choropleth_Geo)
+export(lt_choropleth_GeoCat)
+export(lt_choropleth_GeoNum)
+export(lt_choropleth_Gnm)
+export(lt_choropleth_GnmCat)
+export(lt_choropleth_GnmNum)
 export(lt_legend)

--- a/R/lt-choropleth.R
+++ b/R/lt-choropleth.R
@@ -47,6 +47,7 @@ lt_choropleth <- function(data = NULL,
     na.color = opts_colors$na_color
   )
 
+  zoom_opts <- dsopts_merge(..., categories = "zoom")
   general_opts <- dsopts_merge(..., categories = "map")
   tiles_opts <- dsopts_merge(..., categories = "maptiles")
   highlight_opts <- dsopts_merge(..., categories = "highlight")
@@ -56,7 +57,17 @@ lt_choropleth <- function(data = NULL,
     dsopts_merge(..., categories = "titles")
   )
 
-  lt <- leaflet(data_viz) |>
+  lt <- data_viz |>
+    leaflet(
+      options = leafletOptions(
+        zoomControl = FALSE,
+        zoomSnap = zoom_opts$map_zoom_snap,
+        zoomDelta = zoom_opts$map_zoom_delta,
+        zoom = zoom_opts$zoom_level,
+        minZoom = zoom_opts$zoom_min,
+        maxZoom = zoom_opts$zoom_max
+      )
+    ) |>
     lt_tiles(tiles_opts) |>
     addPolygons(
       fillColor = ~ pal(value),
@@ -84,6 +95,11 @@ lt_choropleth <- function(data = NULL,
 
   lt <- lt |>
     lt_titles(title_opts)
+
+  if (zoom_opts$zoom_show) {
+    lt <- lt |>
+      lt_add_zoom_control(zoom_opts$map_zoom_control_align %||% "topright")
+  }
 
   if (!is.null(data)) {
     lt <- lt |> leaflet::addLegend(

--- a/R/utils-zoom.R
+++ b/R/utils-zoom.R
@@ -1,0 +1,10 @@
+lt_add_zoom_control <- function(lt, zoom_control_align) {
+  lt |>
+    htmlwidgets::onRender(
+      glue::glue(
+        "function(el, x) {{
+          L.control.zoom({{ position: '{zoom_control_align}' }}).addTo(this);
+        }}"
+      )
+    )
+}

--- a/tests/testthat/test-choropleth.R
+++ b/tests/testthat/test-choropleth.R
@@ -53,6 +53,30 @@ test_that("choropleth", {
                 format_sample_num = "1,000.2",
                 map_name_layers = c("col_departments_pacifico", "col_departments_andina"))
 
+  # Opciones de zoom
+  lt_choropleth(data,
+                map_name = "col_departments",
+                var_geo = "name", var_num = "population",
+                zoom_show = FALSE)
+
+  lt_choropleth(data,
+                map_name = "col_departments",
+                var_geo = "name", var_num = "population",
+                zoom_min = 3, zoom_max = 7)
+
+  lt_choropleth(data,
+                map_name = "col_departments",
+                var_geo = "name", var_num = "population",
+                zoom_min = 3, zoom_max = 7,
+                map_zoom_delta = 2)
+
+  lt_choropleth(data,
+                map_name = "col_departments",
+                var_geo = "name", var_num = "population",
+                zoom_min = 3, zoom_max = 7,
+                map_zoom_delta = 0.5,
+                map_zoom_snap = 0.5)
+
 })
 
 test_that("lt_choropleth_Geo", {

--- a/tests/testthat/test-choropleth.R
+++ b/tests/testthat/test-choropleth.R
@@ -54,3 +54,41 @@ test_that("choropleth", {
                 map_name_layers = c("col_departments_pacifico", "col_departments_andina"))
 
 })
+
+test_that("lt_choropleth_Geo", {
+  data <- data.frame(
+    name = c(
+      rep("BOGOTA, D.C.", 5),
+      rep("CAUCA", 3),
+      rep("ANTIOQUIA", 2),
+      rep("MAGDALENA", 1)
+    )
+  )
+
+  lt_choropleth_Geo(data, map_name = "col_departments")
+})
+
+test_that("lt_choropleth_GeoNum", {
+  data <- data.frame(
+    name = c("BOGOTA, D.C.", "CAUCA", "ANTIOQUIA", "MAGDALENA", "MAGDALENA"),
+    population = c(8000000, 1500000, 6500000, 1300000, 32423)
+  )
+
+  lt_choropleth_GeoNum(data, map_name = "col_departments")
+  lt_choropleth_GeoNum(data, map_name = "col_departments", agg = "mean")
+})
+
+test_that("lt_choropleth_GeoCat", {
+  data <- data.frame(
+    name = c(
+      "BOGOTA, D.C.", "CAUCA", "ANTIOQUIA", "MAGDALENA",
+      "SANTANDER", "NARIÑO", "VALLE DEL CAUCA", "META"
+    ),
+    category = c(
+      "A", "B", "C", "D",
+      "B", "C", "A", "D"
+    )
+  )
+
+  lt_choropleth_GeoCat(data, map_name = "col_departments")
+})


### PR DESCRIPTION
- Improved code.
- Modified choropleth logic for including discrete/categoric choroplets.
- Added functions `lt_choropleth_Geo`, `lt_choropleth_GeoNum` and `lt_choropleth_GeoCat`.
- Added aliases for `Gcd` and `Gnm` vars to previous functions.